### PR TITLE
 demangler: fix probable copy-paste error in _parse_special

### DIFF
--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -632,11 +632,11 @@ def _parse_special(cursor):
             return None
         if match.group('kind') == 'V':
             return Node('vtable', name)
-        elif match.group('kind') == 'T' is not None:
+        elif match.group('kind') == 'T':
             return Node('vtt', name)
-        elif match.group('kind') == 'I' is not None:
+        elif match.group('kind') == 'I':
             return Node('typeinfo', name)
-        elif match.group('kind') == 'S' is not None:
+        elif match.group('kind') == 'S':
             return Node('typeinfo_name', name)
     elif match.group('nonvirtual_thunk') is not None:
         func = _parse_encoding(cursor)


### PR DESCRIPTION
The new Python 3.8 SyntaxWarnings made me aware of a few lines in this library that look like obvious copy-paste errors, all of the form

```python
if match.group('kind') == 'T' is not None:
    ...
```

`match.group('kind') == 'T'` will always return a `bool`, so the `is not None` is nonsense, and will cause it to _always_ take the branch.

Note: This PR was initially proposed as whitequark/binja_itanium_cxx_abi#4