### PR TITLE
Add operator template support

### DIFF
--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -476,19 +476,19 @@ def _parse_name(cursor, is_nested=False):
         node = QualNode('abi', node, frozenset(abi_tags))
 
     if not is_nested and cursor.accept('I') and (
-            node.kind == 'name' or
+            node.kind == 'name' or node.kind == 'oper' or
             match.group('std_prefix') is not None or
             match.group('std_name') is not None or
-            match.group('substitution') is not None or
-            match.group('operator_name') is not None):
-        if node.kind == 'name' or match.group('std_prefix') is not None:
+            match.group('substitution') is not None):
+        if node.kind == 'name' or node.kind == 'oper' or match.group('std_prefix') is not None:
             cursor.add_subst(node) # <unscoped-template-name> ::= <substitution>
         templ_args = _parse_until_end(cursor, 'tpl_args', _parse_type)
         if templ_args is None:
             return None
         node = Node('qual_name', (node, templ_args))
-        if (match.group('std_prefix') is not None or
-                match.group('std_name') is not None):
+        if ((match.group('std_prefix') is not None or
+                match.group('std_name') is not None) and
+                node.value[0].value[1].kind != 'oper'):
             cursor.add_subst(node)
 
     return node

--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -479,7 +479,8 @@ def _parse_name(cursor, is_nested=False):
             node.kind == 'name' or
             match.group('std_prefix') is not None or
             match.group('std_name') is not None or
-            match.group('substitution') is not None):
+            match.group('substitution') is not None or
+            match.group('operator_name') is not None):
         if node.kind == 'name' or match.group('std_prefix') is not None:
             cursor.add_subst(node) # <unscoped-template-name> ::= <substitution>
         templ_args = _parse_until_end(cursor, 'tpl_args', _parse_type)

--- a/tests/test.py
+++ b/tests/test.py
@@ -122,6 +122,10 @@ class TestDemangler(unittest.TestCase):
         self.assertDemangles('_ZN2n11fEPNS_1bEPNS_2n21cEPNS2_2n31dE',
                              'n1::f(n1::b*, n1::n2::c*, n1::n2::n3::d*)')
         self.assertDemangles('_ZN1f1gES_IFvvEE', 'f::g(f<void ()>)')
+        self.assertDemangles('_ZplIcET_S0_', 'char operator+<char>(char)')
+        self.assertParses('_ZplIcET_S1_', None)
+        # Operator template results don't get added to substitutions
+        self.assertParses('_ZStplIcEvS0_', None)
 
     def test_abi_tag(self):
         self.assertDemangles('_Z3fooB5cxx11v', 'foo[abi:cxx11]()')

--- a/tests/test.py
+++ b/tests/test.py
@@ -128,3 +128,9 @@ class TestDemangler(unittest.TestCase):
 
     def test_const(self):
         self.assertDemangles('_ZL3foo', 'foo')
+
+    def test_operator_template(self):
+        self.assertDemangles('_ZmiIiE', 'operator-<int>')
+        self.assertDemangles('_ZmiIiEvv', 'void operator-<int>()')
+        self.assertDemangles('_ZmiIiEvKT_RT_', 'void operator-<int>(int const, int&)')
+


### PR DESCRIPTION
Closes #2 
Add support for templated operators, the arg list is parsed and their specialization is not added to the substitution list