### PR TITLE
Add support for array types

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -140,3 +140,7 @@ class TestDemangler(unittest.TestCase):
         self.assertDemangles('_ZmiIiEvv', 'void operator-<int>()')
         self.assertDemangles('_ZmiIiEvKT_RT_', 'void operator-<int>(int const, int&)')
 
+    def test_array(self):
+        self.assertDemangles('_Z1fA1_c', 'f(char[(int)1])')
+        self.assertParses('_Z1fA1c', None)
+


### PR DESCRIPTION
Doesn't implement support for dimension expressions, as that first requires all the expression parsing to be written, and that's a lot more work