### PR TITLE
Fix arrays not being added to substitution

### DIFF
--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -698,6 +698,7 @@ def _parse_type(cursor):
             return None
         type = _parse_type(cursor)
         node = ArrayNode('array', dimension, type)
+        cursor.add_subst(node)
     elif match.group('member_type') is not None:
         cls_ty = _parse_type(cursor)
         member_ty = _parse_type(cursor)

--- a/tests/test.py
+++ b/tests/test.py
@@ -144,6 +144,7 @@ class TestDemangler(unittest.TestCase):
     def test_array(self):
         self.assertDemangles('_Z1fA1_c', 'f(char[(int)1])')
         self.assertDemangles('_Z1fRA1_c', 'f(char(&)[(int)1])')
+        self.assertDemangles('_Z1fIA1_cS0_E', 'f<char[(int)1], char[(int)1]>')
         self.assertParses('_Z1fA1c', None)
 
     def test_function(self):


### PR DESCRIPTION
Array types are valid substitution candidates