### PR TITLE
Fix template ctors having a return type

### DIFF
--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -752,7 +752,9 @@ def _parse_encoding(cursor):
     if cursor.at_end():
         return name
 
-    if name.kind == 'qual_name' and name.value[-1].kind == 'tpl_args' and name.value[-2].kind not in ('ctor', 'dtor'):
+    if name.kind == 'qual_name' \
+            and name.value[-1].kind == 'tpl_args' \
+            and name.value[-2].kind not in ('ctor', 'dtor', 'oper_cast'):
         ret_ty = _parse_type(cursor)
         if ret_ty is None:
             return None

--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -613,11 +613,11 @@ def _parse_name(cursor, is_nested=False):
         node = QualNode('abi', node, frozenset(abi_tags))
 
     if not is_nested and cursor.accept('I') and (
-            node.kind == 'name' or node.kind == 'oper' or
+            node.kind in ('name', 'oper', 'oper_cast') or
             match.group('std_prefix') is not None or
             match.group('std_name') is not None or
             match.group('substitution') is not None):
-        if node.kind == 'name' or node.kind == 'oper' or match.group('std_prefix') is not None:
+        if node.kind in ('name', 'oper', 'oper_cast') or match.group('std_prefix') is not None:
             cursor.add_subst(node) # <unscoped-template-name> ::= <substitution>
         templ_args = _parse_until_end(cursor, 'tpl_args', _parse_type)
         if templ_args is None:
@@ -625,7 +625,7 @@ def _parse_name(cursor, is_nested=False):
         node = Node('qual_name', (node, templ_args))
         if ((match.group('std_prefix') is not None or
                 match.group('std_name') is not None) and
-                node.value[0].value[1].kind != 'oper'):
+                node.value[0].value[1].kind not in ('oper', 'oper_cast')):
             cursor.add_subst(node)
 
     return node

--- a/itanium_demangler/__init__.py
+++ b/itanium_demangler/__init__.py
@@ -752,7 +752,7 @@ def _parse_encoding(cursor):
     if cursor.at_end():
         return name
 
-    if name.kind == 'qual_name' and name.value[-1].kind == 'tpl_args':
+    if name.kind == 'qual_name' and name.value[-1].kind == 'tpl_args' and name.value[-2].kind not in ('ctor', 'dtor'):
         ret_ty = _parse_type(cursor)
         if ret_ty is None:
             return None

--- a/tests/test.py
+++ b/tests/test.py
@@ -25,6 +25,7 @@ class TestDemangler(unittest.TestCase):
         self.assertDemangles('_ZN3fooD0E', 'foo::{deleting dtor}')
         self.assertDemangles('_ZN3fooD1E', 'foo::{dtor}')
         self.assertDemangles('_ZN3fooD2E', 'foo::{base dtor}')
+        self.assertDemangles('_ZN3fooC1IcEEc', 'foo::{ctor}<char>(char)')
 
     def test_operator(self):
         for op in _operators:

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,6 +26,7 @@ class TestDemangler(unittest.TestCase):
         self.assertDemangles('_ZN3fooD1E', 'foo::{dtor}')
         self.assertDemangles('_ZN3fooD2E', 'foo::{base dtor}')
         self.assertDemangles('_ZN3fooC1IcEEc', 'foo::{ctor}<char>(char)')
+        self.assertDemangles('_ZN3fooD1IcEEc', 'foo::{dtor}<char>(char)')
 
     def test_operator(self):
         for op in _operators:
@@ -141,6 +142,9 @@ class TestDemangler(unittest.TestCase):
         self.assertDemangles('_ZmiIiE', 'operator-<int>')
         self.assertDemangles('_ZmiIiEvv', 'void operator-<int>()')
         self.assertDemangles('_ZmiIiEvKT_RT_', 'void operator-<int>(int const, int&)')
+        self.assertDemangles('_ZcviIiE', 'operator int<int>')
+        self.assertDemangles('_ZcviIiEv', 'operator int<int>()')
+        self.assertDemangles('_ZcviIiET_T_', 'operator int<int>(int, int)')
 
     def test_array(self):
         self.assertDemangles('_Z1fA1_c', 'f(char[(int)1])')


### PR DESCRIPTION
If a template is a ctor, dtor, or cast operator, it doesn't ever have a return type. This may not be the most elegant way to do this