### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE-0BSD.txt


### PR DESCRIPTION
Ensure that the license file is part of the source that is published on PyPI.

Sipping the license file is a requirement for various distribution packages. For the Fedora RPM this means that the file has to be downloaded separately from the repo while the rest is coming from PyPI.

It would be nice if you could create a new release after merging this. Thanks 